### PR TITLE
Instantiate generic Object instead of generating random integer.

### DIFF
--- a/src/lonocloud/synthread.clj
+++ b/src/lonocloud/synthread.clj
@@ -11,7 +11,7 @@
   additional constraint that x is marked and checked after each form
   in body to confirm that the mark remains."
   [x & body]
-  (let [val (rand-int Integer/MAX_VALUE)
+  (let [val (Object.)
         do-asserts (gensym "do-asserts-")]
     `(let [x# ~x
            ~do-asserts (impl/iobj? x#)]


### PR DESCRIPTION
Instantiating an Object is a bit over 4x faster and guaranteed not to collide.

user> (time (dotimes [x 10000000](rand-int Integer/MAX_VALUE)))
"Elapsed time: 2229.583833 msecs"

user> (time (dotimes [x 10000000](Object.)))
"Elapsed time: 530.217513 msecs"
